### PR TITLE
Correct import in usage example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ for adx, annotation in enumerate(annotations):
 
 ```python
 import datetime as dt
+import sigmf
 from sigmf import SigMFFile
 
 # suppose we have an complex timeseries signal


### PR DESCRIPTION
The example uses `sigmf.__version__`, so it is necessary to `import sigmf`.